### PR TITLE
Return null when data is not date

### DIFF
--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -195,7 +195,9 @@ trait MetadataAttributeTypeCasterTrait
             case AbstractMetadataRecord::TYPE_BOOLEAN:
                 return !!json_decode($data);
             case AbstractMetadataRecord::TYPE_DATE:
-                return \DateTime::createFromFormat('Y-m-d H:i:s', $data);
+                $date = \DateTime::createFromFormat('Y-m-d H:i:s', $data);
+                
+                return $date instanceof \DateTime ? $date : null;
             case AbstractMetadataRecord::TYPE_ARRAY:
                 return explode(',', $data);
             default:

--- a/tests/CloudApi/GetMetadataTest.php
+++ b/tests/CloudApi/GetMetadataTest.php
@@ -61,6 +61,31 @@ class GetMetadataTest extends TestCase
         $this->assertNull($metadataSet);
     }
     
+    public function testReturnsNullWhenNoDefaultValueForDate()
+    {
+        $serverUrl = 'https://fcapi.example.com';
+        $cloudApiMock = $this->getMockBuilder(AccessibleCloudAdminApi::class)
+            ->setConstructorArgs([$serverUrl])
+            ->setMethods(['init', '__destruct', 'doPost'])
+            ->getMock();
+
+        $mockApiResponse = $this->getSampleResponse();
+
+        $setId = 'aNonExistentId';
+        $cloudApiMock
+            ->expects($this->any())
+            ->method('doPost')
+            ->with("$serverUrl/admin/getmetadataset", http_build_query([
+                'setId' => $setId,
+            ]))
+            ->willReturn($mockApiResponse);
+
+        /** @var CloudAdminAPI $cloudApiMock */
+        $metadataSet = $cloudApiMock->getMetadataSet($setId);
+
+        $this->assertNull($metadataSet->getAttributes()[0]['defaultvalue']);
+    }
+    
     private function getSampleResponse()
     {
         return <<<RESPONSE


### PR DESCRIPTION
Handle data which cannot be successfully converted into a DateTime
object and return null.